### PR TITLE
Fix #707

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -40,7 +40,8 @@ ENV YARN_VERSION 1.5.1
 
 RUN curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-    && ln -snf /opt/yarn-v$YARN_VERSION /opt/yarn \
+    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
     && rm yarn-v$YARN_VERSION.tar.gz
 ```
 


### PR DESCRIPTION
Update documentation on installing a custom yarn version to specify that the /usr/local/bin/yarn* links need updating.